### PR TITLE
chore(ci): bump create-github-app-token to v3 in notify-site

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Mint a token scoped to kaiseki-site
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps `actions/create-github-app-token` from v1 to v3 in `notify-site.yml`, aligning this repo with the rest of the org (most package repos are already on v3). The v3 release adds Node 24 support; this workflow uses no proxy settings, so the v3 breaking change (NODE_USE_ENV_PROXY) does not apply.

Supersedes the per-repo Dependabot bump for this action.